### PR TITLE
add manual testing step before opt tier1 on all platforms

### DIFF
--- a/workgraph/android.yml
+++ b/workgraph/android.yml
@@ -35,18 +35,23 @@ android-debug-tier1:
     title: "Run Android debug builds and tests at tier 1"
     done: true
 
+android-nightlies-manual-test:
+    title: "Verify that the multilocale+en-US+l10n nightlies and associated update methods work via manual testing"
+    dependencies:
+        - android-nightlies-tier2
+
 android-opt-tier1:
     title: "Promote Android opt builds and tests to tier 1, demote in buildbot; 6-12 weeks before beta"
     dependencies:
         - automatic-retry-android-jobs
         - android-opt-tier2
-        - android-nightlies-tier2
+        - android-nightlies-manual-test
         - scriptworker-tier1
 
 android-beta-capable:
     title: "Build shippable android beta release builds"
     dependencies:
-        - android-nightlies-tier2
+        - android-nightlies-manual-test
 
 android-beta-release:
     title: "Ship android beta releases"
@@ -60,7 +65,7 @@ android-release:
         - android-beta-release
 
 android-disable-bb-builds:
-    title: "Turn off the Linux builds on Buildbot (except one for ESR) - will ride trains"
+    title: "Turn off the Android builds on buildbot - will ride trains"
     dependencies:
         - android-debug-tier1
         - android-opt-tier1

--- a/workgraph/linux32.yml
+++ b/workgraph/linux32.yml
@@ -44,7 +44,7 @@ linux32-nightlies-tier2:
 linux32-beta-capable:
     title: "Build shippable linux32 beta release builds"
     dependencies:
-        - linux32-nightlies-tier2
+        - linux32-nightlies-manual-test
 
 linux32-debug-tier1:
     title: "Run linux32 debug builds and tests at tier1"
@@ -52,11 +52,16 @@ linux32-debug-tier1:
         - linux32-builds-tier2
         - linux32-tests-tier2
 
+linux32-nightlies-manual-test:
+    title: "Verify that the linux32 en-US+l10n nightlies and associated update methods work via manual testing"
+    dependencies:
+        - linux32-nightlies-tier2
+
 linux32-opt-tier1:
     title: "Promote all linux32 opt and nightly tasks to tier1, demote Buildbot, start 6-12 week timer to linux32-beta-release"
     # also, disable sendchanges for BB builds to save resources
     dependencies:
-        - linux32-nightlies-tier2
+        - linux32-nightlies-manual-test
         - linux32-debug-tier1
         - scriptworker-tier1
 

--- a/workgraph/linux64.yml
+++ b/workgraph/linux64.yml
@@ -60,14 +60,19 @@ linux64-talos-via-bbb-green:
         - in-tree-bbb-support
         - linux64-builds-tier2
 
+linux64-nightlies-manual-test:
+    title: "Verify that the en-US+l10n nightlies and associated updated methods work via manual testing"
+    dependencies:
+        - linux64-nightlies-tier2
+
 linux64-opt-tier1:
     title: "Promote all windows builds to tier 1, commit for beta in 6-12 weeks"
     # NOTE: this involves:
     #  - running all talos jobs via BBB
     #  - turning off BB talos jobs, demoting builds to tier 2, and disabling sendchanges
     dependencies:
+        - linux64-nightlies-manual-test
         - linux64-debug-tier1
-        - linux64-nightlies-tier2
         - linux64-talos-via-bbb-green
 
 linux64-disable-bb-builds:
@@ -94,7 +99,7 @@ linux64-talos-on-hardware-100pct:
 linux64-beta-capable:
     title: "Build shippable linux64 beta release builds"
     dependencies:
-        - linux64-nightlies-tier2
+        - linux64-nightlies-manual-test
 
 linux64-beta-release:
     title: "Ship linux64 beta release"

--- a/workgraph/macosx.yml
+++ b/workgraph/macosx.yml
@@ -76,6 +76,11 @@ macosx-nightlies-tier2-green:
     dependencies:
         - macosx-nightlies-tier2
 
+macosx-nightlies-manual-test:
+    title: "Verify that the en-US+l10n nightlies and associated updated methods work via manual testing"
+    dependencies:
+        - macosx-nightlies-tier2
+
 macosx-debug-tier1:
     title: "Run macosx debug builds and tests at tier1"
     dependencies:
@@ -85,6 +90,7 @@ macosx-opt-tier1:
     title: "Promote all macosx builds to tier1; turn off macosx buildbot builds and nightlies; commit for beta in 6-12 weeks"
     dependencies:
         - macosx-nightlies-tier2-green
+        - macosx-nightlies-manual-test
         - scriptworker-tier1
         - generic-worker-cot-gpg-keys-in-repo  # any workers that affect artifacts. remove if that's only docker-worker
         - taskcluster-worker-cot-gpg-keys-in-repo
@@ -122,7 +128,7 @@ stop-bb-macosx-test-masters:
 macosx-beta-capable:
     title: "Build shippable macosx beta release builds"
     dependencies:
-        - macosx-nightlies-tier2-green
+        - macosx-nightlies-manual-test
 
 macosx-beta-release:
     title: "Ship macosx beta release"

--- a/workgraph/windows.yml
+++ b/workgraph/windows.yml
@@ -73,6 +73,11 @@ windows-xp-via-bbb-green:
         - in-tree-bbb-support
         - windows-builds-tier2
 
+windows-nightlies-manual-test:
+    title: "Verify that the en-US+l10n nightlies and associated updated methods work via manual testing"
+    dependencies:
+        - windows-nightlies-tier2
+
 windows-opt-tier1:
     title: "Promote all windows builds to tier1; turn off windows buildbot builds and nightlies; commit for beta in 6-12 weeks"
     # NOTE: this involves
@@ -83,9 +88,9 @@ windows-opt-tier1:
         - generic-worker-cot-gpg-keys-in-repo
         - taskcluster-worker-cot-gpg-keys-in-repo
         - windows-debug-tier1
-        - windows-nightlies-tier2
         - windows-talos-via-bbb-green
         - windows-tests-tier2
+        - windows-nightlies-manual-test
         - windows-xp-via-bbb-green
 
 windows-disable-bb-builds:
@@ -131,7 +136,7 @@ stop-bb-windows-test-masters:
 windows-beta-capable:
     title: "Build shippable windows beta release builds"
     dependencies:
-        - windows-nightlies-tier2
+        - windows-nightlies-manual-test
 
 windows-beta-release:
     title: "Ship windows beta release"


### PR DESCRIPTION
This may involve the qa team, though we can do our own spot testing.
