### PR TITLE
Updates for 2016-11-01

### DIFF
--- a/workgraph/android.yml
+++ b/workgraph/android.yml
@@ -27,6 +27,7 @@ android-single-locale-signing-tier2:
     title: "Sign android single-locale repacks"
     description: |
         Implement task-graph tasks that will sign the single-locale repacks
+    done: true
     dependencies:
         - android-single-locale-tier2
 
@@ -58,6 +59,7 @@ android-single-locale-balrog-tier2:
 android-verify-signing-equivalence:
     # ask coop for details
     title: "Verify that the signature formats match those from BB builds"
+    assigned: Callek
     dependencies:
         - android-signing-tier2
         - android-single-locale-signing-tier2
@@ -69,8 +71,6 @@ android-nightlies-tier2:
         - android-single-locale-tier2
         - android-signing-tier2
         - android-verify-signing-equivalence
-        - android-balrog-tier2
-        - android-single-locale-balrog-tier2
         - nightly-beetmover-tier2
         - nightly-single-locale-beetmover-tier2
 
@@ -101,6 +101,8 @@ android-opt-tier1:
         - android-opt-tier2
         - android-nightlies-manual-test
         - scriptworker-tier1
+        - android-balrog-tier2
+        - android-single-locale-balrog-tier2
 
 android-beta-release:
     title: "Ship android beta releases"

--- a/workgraph/linux32.yml
+++ b/workgraph/linux32.yml
@@ -56,12 +56,14 @@ linux32-single-locale-signing-tier2:
     title: "Sign linux32 single-locale repacks"
     description: |
         Implement task-graph tasks that will sign the single-locale repacks
+    done: true
     dependencies:
         - linux32-single-locale-tier2
 
 linux32-verify-signing-equivalence:
     # ask coop for details
     title: "Verify that the signature formats match those from BB builds"
+    assigned: Callek
     dependencies:
         - linux32-signing-tier2
         - linux32-single-locale-signing-tier2
@@ -71,8 +73,6 @@ linux32-nightlies-tier2:
     dependencies:
         - linux32-builds-tier2
         - linux32-signing-tier2
-        - linux32-balrog-tier2
-        - linux32-single-locale-balrog-tier2
         - linux32-single-locale-tier2
         - linux32-verify-signing-equivalence
         - nightly-beetmover-tier2
@@ -107,6 +107,8 @@ linux32-opt-tier1:
         - orange-builds
         - linux32-debug-tier1
         - scriptworker-tier1
+        - linux32-balrog-tier2
+        - linux32-single-locale-balrog-tier2
 
 linux32-disable-bb-builds:
     title: "Turn off all Linux32 builds on Buildbot"

--- a/workgraph/linux64.yml
+++ b/workgraph/linux64.yml
@@ -64,12 +64,14 @@ linux64-single-locale-signing-tier2:
     title: "Sign linux64 single-locale repacks"
     description: |
         Implement task-graph tasks that will sign the single-locale repacks
+    done: true
     dependencies:
         - linux64-single-locale-tier2
 
 linux64-verify-signing-equivalence:
     # ask coop for details
     title: "Verify that the signature formats match those from BB builds"
+    assigned: Callek
     dependencies:
         - linux64-signing-tier2
         - linux64-single-locale-signing-tier2
@@ -81,8 +83,6 @@ linux64-nightlies-tier2:
         - linux64-tests-tier2
         - linux64-signing-tier2
         - linux64-verify-signing-equivalence
-        - linux64-balrog-tier2
-        - linux64-single-locale-balrog-tier2
         - linux64-single-locale-tier2
         - nightly-beetmover-tier2
         - nightly-single-locale-beetmover-tier2
@@ -120,6 +120,8 @@ linux64-opt-tier1:
         - linux64-nightlies-manual-test
         - linux64-debug-tier1
         - linux64-talos-via-bbb-green
+        - linux64-balrog-tier2
+        - linux64-single-locale-balrog-tier2
 
 linux64-disable-bb-builds:
     title: "Turn off the Linux64 builds on Buildbot"

--- a/workgraph/milestones.yml
+++ b/workgraph/milestones.yml
@@ -14,11 +14,11 @@ win7-testing-tier2:
 linux-android-nightlies-tier2:
     title: "Linux32/64 and android nightlies at tier2"
     milestone: true
-    due: 2016-11-01
+    due: 2016-11-08
     description: |
         Nightlies for the linux32, linux64, and Android platforms are
-        implemented on a project branch, and produce updates that can be
-        dogfooded by team members.
+        implemented on a project branch, and can be dogfooded by team members.
+        Updates are not included,
     dependencies:
         - linux32-nightlies-tier2
         - linux64-nightlies-tier2

--- a/workgraph/multiplatform.yml
+++ b/workgraph/multiplatform.yml
@@ -45,6 +45,7 @@ beetmover-worker-impl:
     # "beetworker"?
     title: "Implement and deploy a Beetmoover Worker based on scriptworker"
     bug: 1282188
+    done: true
     assigned: mtabara
 
 balrog-worker-impl:
@@ -63,7 +64,7 @@ docker-worker-retry-on:
 
 nightly-beetmover-tier2:
     title: "beetmover tasks implemented in-tree for tier2 platforms"
-    assigned: mtabara
+    assigned: kmoir
     dependencies:
         - beetmover-worker-impl
 
@@ -72,6 +73,7 @@ nightly-single-locale-beetmover-tier2:
     description: |
         Implement tasks for beetmover that can handle the additional complexity of
         artifact names containing locale names.
+    assigned: kmoir
     dependencies:
         - beetmover-worker-impl
 
@@ -96,6 +98,7 @@ taskcluster-worker-cot-gpg-keys-in-repo:
 
 scriptworker-chain-of-trust-verification:
     title: "Enable chain of trust verification, and block on it before scriptworker jobs"
+    assigned: aki
 
 scriptworker-queue-monitoring:
     title: "Monitor scriptworker queues and alert when too large"


### PR DESCRIPTION
 * Make *-balrog-tier2 items block tier-1 deployment, not tier-2 nightlies
 * update 'done' status for beetmover-worker-impl and
   *-single-locale-signing
 * update assignments based on meeting notes

Open question: are `nightly-single-locale-beetmover-tier2` and `nightly-beetmover-tier2` different?  Or maybe it doesn't even matter if they're almost done?

@ccooper @escapewindow @Callek @MihaiTabara @lundjordan