### PR TITLE
pushapk no longer blocks nightly tier1

### DIFF
--- a/workgraph/multiplatform.yml
+++ b/workgraph/multiplatform.yml
@@ -160,7 +160,6 @@ scriptworker-tier1:
     dependencies:
         - scriptworker-chain-of-trust-verification
         - beetmover-chain-of-trust
-        - pushapk-chain-of-trust
         - balrog-chain-of-trust
         - scriptworker-queue-monitoring
         - scriptworker-nagios

--- a/workgraph/releasetasks.yml
+++ b/workgraph/releasetasks.yml
@@ -29,6 +29,18 @@ releasetasks-funsize-sched-in-tree:
     dependencies:
         - releasetasks-funsize-sched-tc-pulse
 
+releasetasks-pushapk-sched-tc-pulse:
+    title: "Modify the pushapk scheduler to listen to pulse events from TC"
+    description: |
+        This is an intermediate step that allows pushapk tasks to operate
+        against release builds performed in TC
+
+releasetasks-pushapk-sched-in-tree:
+    title: "Replace the pushapk scheduler with tasks generated in-tree"
+    dependencies:
+        - releasetasks-pushapk-sched-tc-pulse
+        - pushapk-chain-of-trust
+
 releasetasks-partner-repacks-macosx:
     title: "Implement partner repacks for MacOS X"
     dependencies:
@@ -101,3 +113,4 @@ stop-releasetasks-via-bbb:
         - releasetasks-eme-free-repacks
         - releasetasks-sha1-repacks
         - releasetasks-funsize-sched-in-tree
+        - releasetasks-pushapk-sched-in-tree


### PR DESCRIPTION
We're planning on more of a funsize model, where we're pulse-based, so I've modeled the pushapk tasks after that.