### PR TITLE
Add Android x86 to the tier 1 critical path

### DIFF
--- a/workgraph/android.yml
+++ b/workgraph/android.yml
@@ -76,12 +76,17 @@ android-single-locale-balrog-tier2:
         - balrog-worker-impl
 
 android-verify-signing-equivalence:
-    # ask coop for details
     title: "Verify that the signature formats match those from BB builds"
     assigned: Callek
     dependencies:
         - android-signing-tier2
         - android-single-locale-signing-tier2
+
+android-x86-verify-signing-equivalence:
+    title: "Verify that the signature formats match those from BB builds"
+    assigned: Callek
+    dependencies:
+        - android-signing-tier2
 
 android-nightlies-tier2:
     title: "Run Android opt nightlies at tier 2"
@@ -117,8 +122,21 @@ android-nightlies-manual-test:
     dependencies:
         - android-nightlies-tier2
 
+android-x86-nightlies-manual-test:
+    # this is update testing, possibly done by triggering some of QA's tests against a nightly made on date
+    title: "Verify that the Android x86 nightlies and associated update methods work via manual testing"
+    assigned: Callek
+    dependencies:
+        - android-x86-nightlies-tier2
+
 android-verify-build-equivalence:
     title: "Verify TC-dervied builds are byte-for-byte equivalent to BB builds"
+    assigned: Callek
+    dependencies:
+        - android-opt-tier2
+
+android-x86-verify-build-equivalence:
+    title: "Verify TC-dervied x86 builds are byte-for-byte equivalent to BB builds"
     assigned: Callek
     dependencies:
         - android-opt-tier2
@@ -135,16 +153,41 @@ android-opt-tier1:
         - android-nightlies-manual-test
         - scriptworker-tier1
 
+android-x86-tier1:
+    title: "Promote Android x86 builds and tests to tier 1, demote in buildbot; 6-12 weeks before beta"
+    dependencies:
+        - android-x86-verify-build-equivalence
+        - android-x86-verify-signing-equivalence
+        - docker-worker-cot-gpg-keys-in-repo
+        - automatic-retry-android-jobs
+        - pulse-actions-backfill
+        - android-x86-tier2
+        - android-x86-nightlies-manual-test
+        - scriptworker-tier1
+
 android-beta-release:
     title: "Ship android beta releases"
+    assigned: jlorenzo
     dependencies:
         - android-nightlies-manual-test
         - android-opt-tier1
+
+android-x86-beta-release:
+    title: "Ship android x86 beta releases"
+    assigned: jlorenzo
+    dependencies:
+        - android-x86-nightlies-manual-test
+        - android-x86-tier1
 
 android-release:
     title: "Ship android release"
     dependencies:
         - android-beta-release
+
+android-x86-release:
+    title: "Ship android x86 release"
+    dependencies:
+        - android-x86-beta-release
 
 android-disable-bb-builds:
     title: "Turn off the Android builds on buildbot - will ride trains"

--- a/workgraph/linux32.yml
+++ b/workgraph/linux32.yml
@@ -117,7 +117,8 @@ linux32-opt-tier1:
         - linux32-partial-updates
 
 linux32-partial-updates:
-    title: "Generate, sign, and publish partial updates for linux32 nightly builds"
+    title: "Integrate partial update generation into the CoT for linux32 nightly builds"
+    assigned: sfraser
     dependencies:
         - linux32-signing-tier2
 
@@ -129,6 +130,7 @@ linux32-disable-bb-builds:
 
 linux32-beta-release:
     title: "Ship a real linux32 beta release"
+    assigned: jlorenzo
     dependencies:
         - linux32-nightlies-manual-test
         - linux32-opt-tier1

--- a/workgraph/linux64.yml
+++ b/workgraph/linux64.yml
@@ -130,7 +130,8 @@ linux64-opt-tier1:
         - linux64-partial-updates
 
 linux64-partial-updates:
-    title: "Generate, sign, and publish partial updates for linux64 nightly builds"
+    title: "Integrate partial update generation into the CoT for linux64 nightly builds"
+    assigned: sfraser
     dependencies:
         - linux64-signing-tier2
 
@@ -171,6 +172,7 @@ linux64-talos-on-hardware-100pct:
 
 linux64-beta-release:
     title: "Ship linux64 beta release"
+    assigned: jlorenzo
     dependencies:
         - linux64-nightlies-manual-test
         - linux64-opt-tier1

--- a/workgraph/milestones.yml
+++ b/workgraph/milestones.yml
@@ -53,6 +53,7 @@ linux-android-tier1:
         - linux32-opt-tier1
         - linux64-opt-tier1
         - android-opt-tier1
+        - android-x86-tier1
 
 linux64-talos-on-hardware:
     title: "Linux64 Talos is running via TC worker on hardware"
@@ -83,6 +84,7 @@ all-releases:
         on all TaskCluster.
     dependencies:
         - android-release
+        - android-x86-release
         - linux32-release
         - linux64-release
         - macosx-release


### PR DESCRIPTION
Assign verification tasks to Callek
Assign partial generation tasks to sfraser
Assign beta release task for Linux/Android to jlorenzo <- we'll need a
better task breakdown for this as we investigate it.