### PR TITLE
clean up linux/android milestones; add untracked tasks

### DIFF
--- a/workgraph/android.yml
+++ b/workgraph/android.yml
@@ -183,6 +183,9 @@ android-x86-tier1:
         - android-x86-nightlies-manual-test
         - scriptworker-tier1
 
+new-apk-dep-key:
+    title: "Create a new android apk dep signing key, and use it in signing servers"
+
 android-beta-release:
     title: "Ship android beta releases"
     assigned: jlorenzo

--- a/workgraph/android.yml
+++ b/workgraph/android.yml
@@ -158,6 +158,7 @@ android-x86-verify-build-equivalence:
 android-opt-tier1:
     title: "Promote Android opt builds and tests to tier 1, demote in buildbot; 6-12 weeks before beta"
     bug: 1277682
+    done: true
     dependencies:
         - android-verify-build-equivalence
         - android-verify-signing-equivalence
@@ -167,11 +168,11 @@ android-opt-tier1:
         - android-opt-tier2
         - android-nightlies-manual-test
         - scriptworker-tier1
-        - nightly-checksum-signing
 
 android-x86-tier1:
     title: "Promote Android x86 builds and tests to tier 1, demote in buildbot; 6-12 weeks before beta"
     bug: 1298894
+    done: true
     dependencies:
         - android-x86-verify-build-equivalence
         - android-x86-verify-signing-equivalence
@@ -181,7 +182,6 @@ android-x86-tier1:
         - android-x86-tier2
         - android-x86-nightlies-manual-test
         - scriptworker-tier1
-        - nightly-checksum-signing
 
 android-beta-release:
     title: "Ship android beta releases"

--- a/workgraph/linux32.yml
+++ b/workgraph/linux32.yml
@@ -127,7 +127,7 @@ linux32-opt-tier1:
         - linux32-debug-tier1
         - scriptworker-tier1
         - linux32-partial-updates
-        - nightly-checksum-signing
+    done: true
 
 linux32-partial-updates:
     title: "Generate partial updates for linux32 nightly builds using the existing funsize worker"

--- a/workgraph/linux64.yml
+++ b/workgraph/linux64.yml
@@ -137,7 +137,7 @@ linux64-opt-tier1:
         - linux64-debug-tier1
         - linux64-talos-via-bbb-green
         - linux64-partial-updates
-        - nightly-checksum-signing
+    done: true
 
 linux64-partial-updates:
     title: "Generate partial updates for linux64 nightly builds using the existing funsize worker"

--- a/workgraph/milestones.yml
+++ b/workgraph/milestones.yml
@@ -10,6 +10,9 @@ linux-android-tier1-cleanup:
     dependencies:
         - scriptworker-iptables
         - scriptworker-ssh-alerts
+        - scriptworker-nagios
+        - scriptworker-queue-monitoring
+        - nightly-checksum-signing
         - pulse-actions-missing-talos
         - artifact-list-changes
         - declarative-manifests
@@ -70,6 +73,7 @@ linux-android-tier1:
         - linux64-opt-tier1
         - android-opt-tier1
         - android-x86-tier1
+    done: true
 
 linux64-talos-on-hardware:
     title: "Linux64 Talos is running via TC worker on hardware"

--- a/workgraph/milestones.yml
+++ b/workgraph/milestones.yml
@@ -12,12 +12,18 @@ linux-android-tier1-cleanup:
         - scriptworker-ssh-alerts
         - scriptworker-nagios
         - scriptworker-queue-monitoring
+        - scriptworker-cancel-tasks
+        - scriptworker-audit-new-instance-types
+        - new-apk-dep-key
+        - cot-rebuild-decision-task
         - nightly-checksum-signing
         - pulse-actions-missing-talos
         - artifact-list-changes
         - declarative-manifests
         - add-jobs-e10s
         - trychooser-e10s
+        - allow-many-routes
+        - separate-tier3-gpg-keys
 
 win7-testing-tier2:
     title: "Windows 7 non-hardware tests successfully running in TC against TC builds"

--- a/workgraph/multiplatform.yml
+++ b/workgraph/multiplatform.yml
@@ -171,12 +171,11 @@ scriptworker-tier1:
     title: "Scriptworker is tier1-ready"
     assigned: aki
     bug: 1317789
+    done: true
     dependencies:
         - scriptworker-chain-of-trust-verification
         - beetmover-chain-of-trust
         - balrog-chain-of-trust
-        - scriptworker-queue-monitoring
-        - scriptworker-nagios
         - docker-image-sha-doesnt-match
 
 make-check-ok-for-cross-compile:

--- a/workgraph/multiplatform.yml
+++ b/workgraph/multiplatform.yml
@@ -106,6 +106,10 @@ docker-worker-cot-gpg-keys-in-repo:
     assigned: garndt
     done: true
 
+separate-tier3-gpg-keys:
+    title: separate the gpg keys for tier3 workers from non-tier3
+    bug: 1333650
+
 generic-worker-cot-gpg-keys-in-repo:
     title: "Set up a process for generating and adding keys to the cot gpg repo for every generic-worker deployment (reimage or AMI generation)"
     description: |
@@ -162,6 +166,9 @@ scriptworker-iptables:
     duration: 5
     bug: 1308980
 
+scriptworker-audit-new-instance-types:
+    title: "audit the new scriptworker instance types for rra/pentest compliance"
+
 scriptworker-ssh-alerts:
     title: "Alerts on ssh to scriptworker instances"
     bug: 1290261
@@ -177,6 +184,33 @@ scriptworker-tier1:
         - beetmover-chain-of-trust
         - balrog-chain-of-trust
         - docker-image-sha-doesnt-match
+
+cot-rebuild-decision-task:
+    title: verify chain of trust by rebuilding the decision task
+    assigned: aki
+    bug: 1328719
+    dependencies:
+        - cron-tasks
+        - in-tree-docker-shas
+        - in-tree-mozilla-taskcluster
+
+cron-tasks:
+    title: allow for in-tree cron tasks
+    assigned: dustin
+    bug: 1252948
+
+in-tree-docker-shas:
+    title: move decision and docker-image docker image shas in-tree
+    bug: 1326436
+
+in-tree-mozilla-taskcluster:
+    title: move mozilla-taskcluster tree info in-tree
+    bug: 1328727
+
+allow-many-routes:
+    title: get around max 4k index routes with a dummy task
+    assigned: jonasfj
+    bug: 1333255
 
 make-check-ok-for-cross-compile:
     title: "For each make-check check, either split it to a test task, confirm it runs in cross-compilation, or remove"
@@ -292,6 +326,9 @@ taskcluster-worker-setup-cleanup:
         (clearing temporary directories, killing stray processes, etc.).  We
         will need similar functionality with taskcluster-worker, either by
         using runner or implementing it with some other mechanism
+
+scriptworker-cancel-tasks:
+    title: "Support for cancelling tasks in scriptworker"
 
 taskcluster-worker-cancel-tasks:
     title: "Support for cancelling tasks in taskcluster-worker"


### PR DESCRIPTION
During the nightly migration meeting I noticed there were a lot of tasks untracked in the migration repo.  I've added them, though we may want to reschedule when they're due.