### PR TITLE
Updates 2017 01 30

### DIFF
--- a/workgraph/macosx.yml
+++ b/workgraph/macosx.yml
@@ -220,6 +220,7 @@ macosx-test-talos-on-hardware-100pct:
     dependencies:
         - macosx-test-talos-on-hardware-green
         - macosx-taskcluster-worker-integration-testing
+        - macosx-nightlies-tier1
 
 stop-bb-macosx-test-masters:
     title: "Turn off the MacOS X Test Buildmasters (except one for ESR)"

--- a/workgraph/multiplatform.yml
+++ b/workgraph/multiplatform.yml
@@ -319,15 +319,11 @@ fuzzing:
 
 taskcluster-worker-setup-cleanup:
     title: "Add support to Taskcluster-Worker for pre-task setup and post-task cleanup work"
-    duration: 20
-    description: |
-        For Buildbot jobs, runner takes care of some pre-task setup (warming
-        caches, for example, to reduce end-to-end time) and post-task cleanup
-        (clearing temporary directories, killing stray processes, etc.).  We
-        will need similar functionality with taskcluster-worker, either by
-        using runner or implementing it with some other mechanism
+    duration: 5
+    description: It turns out we didn't need this.
     assigned: dustin
     bug: 1333888
+    done: true
 
 scriptworker-cancel-tasks:
     title: "Support for cancelling tasks in scriptworker"


### PR DESCRIPTION
@ccooper: somehow the OS X test deployment and the OS X nightly work had come un-stuck from one another, so we were missing the entire dependency chain of releases and nightlies.

This doesn't push the schedule out too badly, but it's a big difference!